### PR TITLE
refactor: use fetch api instead of axios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import App from '../src/app.js';
 
 
-window.json = async fileName=>(await axios(`../data/${fileName}.json`)).data;
+window.json = async fileName => await (await fetch(`../data/${fileName}.json`)).json();
 
 // Pssst, I've created a github package - https://github.com/brookesb91/dismissible
 const hideBanners = (e) => {

--- a/view/index.html
+++ b/view/index.html
@@ -8,7 +8,6 @@
     <meta name="keywords" content="人生重开模拟器 liferestart life restart remake 人生重来"/>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="../public/bundle.js"></script>
     <title>Life Restart</title>
 </head>


### PR DESCRIPTION
`axios` sucks. Why not use the native `fetch` API instead?