### PR TITLE
fix: missing public path '/lib' in webpack config

### DIFF
--- a/view/dark.css
+++ b/view/dark.css
@@ -395,28 +395,57 @@ ul#total li .achievementtitle,
   }
 }
 
-.grade0b.selected {
-  background-color: #c0c0c0 !important;
+.grade0b.selected,
+.grade1b.selected,
+.grade2b.selected,
+.grade3b.selected {
   box-shadow: #ccc 0px 0px 10px;
   color: #3b3b3b;
+  overflow: hidden;
+}
+.grade0b.selected.selected::after,
+.grade1b.selected.selected::after,
+.grade2b.selected.selected::after,
+.grade3b.selected.selected::after {
+  content: '';
+  position: absolute;
+  background-image: linear-gradient(to left, transparent, #fff 50%, transparent 100%);
+  opacity: 1;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  opacity: 0;
+  animation: blink 2s linear infinite;
+}
+
+@keyframes blink {
+  0% {
+    opacity: 0;
+    transform: translateX(-100vw);
+  }
+  50% {
+    opacity: .5;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(80px);
+  }
+}
+
+.grade0b.selected {
+  background-color: #c0c0c0 !important;
 }
 
 .grade1b.selected {
   background-color: #87cefa !important;
-  box-shadow: #ccc 0px 0px 10px;
-  color: #3b3b3b;
 }
 
 .grade2b.selected {
   background-color: #e7beff !important;
-  box-shadow: #ccc 0px 0px 10px;
-  color: #3b3b3b;
 }
 
 .grade3b.selected {
   background-color: #f1bfac !important;
-  box-shadow: #ccc 0px 0px 10px;
-  color: #3b3b3b;
 }
 
 .propinitial {

--- a/view/light.css
+++ b/view/light.css
@@ -622,28 +622,57 @@ i {
   }
 }
 
-.grade0b.selected {
-  background-color: #444 !important;
+.grade0b.selected,
+.grade1b.selected,
+.grade2b.selected,
+.grade3b.selected {
   box-shadow: #bbb 0px 0px 10px;
   color: #fff;
+  overflow: hidden;
+}
+.grade0b.selected.selected::after,
+.grade1b.selected.selected::after,
+.grade2b.selected.selected::after,
+.grade3b.selected.selected::after {
+  content: '';
+  position: absolute;
+  background-image: linear-gradient(to left, transparent, #fff 50%, transparent 100%);
+  opacity: 1;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  opacity: 0;
+  animation: blink 2s linear infinite;
+}
+
+@keyframes blink {
+  0% {
+    opacity: 0;
+    transform: translateX(-100vw);
+  }
+  50% {
+    opacity: .5;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(80px);
+  }
+}
+
+.grade0b.selected {
+  background-color: #444 !important;
 }
 
 .grade1b.selected {
   background-color: #407dec !important;
-  box-shadow: #bbb 0px 0px 10px;
-  color: #fff;
 }
 
 .grade2b.selected {
   background-color: #b362e7 !important;
-  box-shadow: #bbb 0px 0px 10px;
-  color: #fff;
 }
 
 .grade3b.selected {
   background-color: #ff7f4d !important;
-  box-shadow: #bbb 0px 0px 10px;
-  color: #fff;
 }
 
 @keyframes banner-in {

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -22,6 +22,10 @@ module.exports = {
         directory: path.join(__dirname, 'src'),
         publicPath: '/src',
       },
+      {
+        directory: path.join(__dirname, 'lib'),
+        publicPath: '/lib',
+      }
     ],
   },
   output: {


### PR DESCRIPTION
After developers starting the dev server and visiting localhost from browsers, UI will appears pure white because the dev server didn't host the `/lib` directory, browsers cannot find global dependencies such as jQuery.