### PR TITLE
updata condition.js

### DIFF
--- a/src/functions/condition.js
+++ b/src/functions/condition.js
@@ -90,7 +90,7 @@ function checkProp(property, condition) {
             if (Array.isArray(propData)) {
                 if (propData.length != conditionData.length) 
                     return false
-                for (let p of propData) 
+                for (const p of propData) 
                     if (!conditionData.includes(p)) return false
                 return true
             }
@@ -99,11 +99,11 @@ function checkProp(property, condition) {
             if (Array.isArray(propData)) {
                 if (propData.length != conditionData.length) 
                     return true
-                for (let p of propData) 
+                for (const p of propData) 
                     if (!conditionData.includes(p)) return true
                 return false
             }
-            return propData == conditionData
+            return propData != conditionData
         case '?':
             if(Array.isArray(propData)) {
                 for(const p of propData)

--- a/src/functions/condition.js
+++ b/src/functions/condition.js
@@ -87,13 +87,23 @@ function checkProp(property, condition) {
         case '>=': return propData >= conditionData;
         case '<=': return propData <= conditionData;
         case '=':
-            if(Array.isArray(propData))
-                return propData.includes(conditionData);
-            return propData == conditionData;
+            if (Array.isArray(propData)) {
+                if (propData.length != conditionData.length) 
+                    return false
+                for (let p of propData) 
+                    if (!conditionData.includes(p)) return false
+                return true
+            }
+            return propData == conditionData
         case '!=':
-            if(Array.isArray(propData))
-                return !propData.includes(conditionData);
-            return propData != conditionData;
+            if (Array.isArray(propData)) {
+                if (propData.length != conditionData.length) 
+                    return true
+                for (let p of propData) 
+                    if (!conditionData.includes(p)) return true
+                return false
+            }
+            return propData == conditionData
         case '?':
             if(Array.isArray(propData)) {
                 for(const p of propData)


### PR DESCRIPTION
修改原因：在 proData 是Array类型的的情况下 ，无法判断传入的 conditionData 是Array类型

bug复现方式：
传入参数prop = { EVT:[ 5,6,7] }，分别传入判断条件： 'EVT=[5,6,7]' 和 'EVT=5',

分析 ：现有的data目录中event.json的数据中未见“=”与“!=”，所以没有bug反馈