### PR TITLE
Update webpack.config.cjs

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
         publicPath: '/src',
       },
     ],
+    allowedHosts: "all",
   },
   output: {
     path: path.resolve(__dirname, 'public/chunk'),


### PR DESCRIPTION
当前版本部署到网站时，如果绑定了域名，会出现“Invalid Host header”。这个问题之所以出现是因为 webpack-dev-server 2.4.4 增加了主机检查，需要禁用 host check 或者添加允许的 host。

When the current version is deployed to a website, if a domain name is bound, an "Invalid Host header" will appear. The problem occurs because webpack-dev-server 2.4.4 adds a host check, which needs to be disabled or an allowed host added.